### PR TITLE
44/user-event-orphans

### DIFF
--- a/lib/jobs/process_daily_user_activity.rb
+++ b/lib/jobs/process_daily_user_activity.rb
@@ -108,14 +108,15 @@ module Jobs
 
       # create UserEvent from any remaining events
       @events.each do |e|
-        # if within_time_delta?(e[:timestamp], end_of_day, 10)
-        Models::UserEvent.create(
-          address: address,
-          coordinates: e[:coordinates],
-          event: e[:event],
-          position: e[:position],
-          timestamp: e[:timestamp]
-        )
+        if within_time_delta?(e[:timestamp], end_of_day, 30)
+          Models::UserEvent.create(
+            address: address,
+            coordinates: e[:coordinates],
+            event: e[:event],
+            position: e[:position],
+            timestamp: e[:timestamp]
+          )
+        end
       end
 
       # TODO: separate job


### PR DESCRIPTION
i think this is enough to deal with things - in theory it should save enough data to still correctly calculate all data but not so much data that things start to pile up. and the old orphaned user events should simply be deleted