### PR TITLE
Save serialized global scene stats separately

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,6 +96,17 @@ namespace :compute do
       message: result
     )
   end
+
+  desc "build and serialize yesterday's global scene stats"
+  task :create_serialized_global_scene_stats do
+    require './lib/main'
+
+    data_json = Serializers::Global::Scenes.serialize.to_json
+    Models::SerializedDailySceneStats.create(
+      date: (Date.today - 1).to_s,
+      data_json: data_json
+    )
+  end
 end
 
 namespace :data_preservation do

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -36,6 +36,7 @@ require './lib/models/daily_parcel_stats.rb'
 require './lib/models/daily_scene_stats.rb'
 require './lib/models/parcel_traffic.rb'
 require './lib/models/api_response_status.rb'
+require './lib/models/serialized_daily_scene_stats.rb'
 
 # require adapters
 require 'faraday'

--- a/lib/models/serialized_daily_scene_stats.rb
+++ b/lib/models/serialized_daily_scene_stats.rb
@@ -1,0 +1,16 @@
+# primary_key :id
+#
+# Date    :date,            null: false
+# Jsonb   :data_json,       null: false
+#
+# Time    :created_at,      null: false
+#
+# add_index :serialized_daily_scene_stats, [:date], unique: true
+
+module Models
+  class SerializedDailySceneStats < Sequel::Model
+    def data
+      JSON.parse(data_json)
+    end
+  end
+end

--- a/migrations/031_create_serialized_global_scene_stats.rb
+++ b/migrations/031_create_serialized_global_scene_stats.rb
@@ -1,0 +1,16 @@
+print "creating serialized_daily_scene_stats table\n"
+
+Sequel.migration do
+  change do
+    create_table(:serialized_daily_scene_stats) do
+      primary_key :id
+
+      Date    :date,            null: false
+      Jsonb   :data_json,       null: false
+
+      Time    :created_at,      null: false
+    end
+
+    add_index :serialized_daily_scene_stats, [:date], unique: true
+  end
+end

--- a/server.rb
+++ b/server.rb
@@ -29,7 +29,7 @@ class Server < Sinatra::Application
     {
       global: Serializers::Global::DailyStats.serialize,
       parcels: Serializers::Global::Parcels.serialize,
-      scenes: Serializers::Global::Scenes.serialize,
+      scenes: Models::SerializedDailySceneStats.order(:date).last.data,
       users: Serializers::Global::Users.serialize
     }.to_json
   end


### PR DESCRIPTION
the problem is that the queries for building global scene stats take a significant amount of time cause there's a lot of data to go through and a lot of separate queries. There is probably a way to build this data lightning fast with pure SQL but :shrug: - so instead i'm creating a separate db table, running the calculation and serialization as a rake task and saving it to that table, then just serving the data from the table. 

this kind of sucks but i can't think of a better way to do it + this solution is very quick to implement